### PR TITLE
ci (e2e): run e2e tests only on pr events

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/docker_utils.yml
   e2e:
     needs: docker
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest-16-core
     steps:
       - name: Set environment


### PR DESCRIPTION
# Description

This PR adds a condition on running the e2e tests so that they're only run on PR events.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
