### PR TITLE
feat: return explicit execute errors

### DIFF
--- a/src/execute/execute.errors.ts
+++ b/src/execute/execute.errors.ts
@@ -1,20 +1,39 @@
-export enum PROVIDER_ERRORS {
-  INVALID_ENDPOINT = 'Provider // Invalid endpoint!',
-}
-
-export enum CONTRACT_ERRORS {
-  INVALID_CONTRACT = 'Contract // Invalid contract!',
-}
-
-export enum WALLET_ERRORS {
-  INVALID_PRIVATE_KEY = 'Wallet // Invalid private key!',
-}
-
 export enum QUEUE_ERRORS {
   JOB_NOT_FOUND = 'Queue // A job with the provided id could not be found!',
   REDIS_NOT_AVAILABLE = 'Queue // Could not connect to Redis!',
 }
 
-export enum JOB_ERRORS {
-  MISSING_CERTIFICATE = 'Job // Could not find the related certificate!',
+export enum ExecuteProcessorError {
+  PROVIDER_INVALID_ENDPOINT = 'PROVIDER_INVALID_ENDPOINT',
+  CONTRACT_INVALID_ADDRESS = 'CONTRACT_INVALID_ADDRESS',
+  CONTRACT_INVALID_NO_CODE = 'CONTRACT_INVALID_NO_CODE',
+  WALLET_INVALID_PRIVATE_KEY = 'WALLET_INVALID_PRIVATE_KEY',
+  CERTIFICATE_NOT_FOUND = 'CERTIFICATE_NOT_FOUND',
+  EXECUTE_TRANSACTION_FAILED_INIT = 'EXECUTE_TRANSACTION_FAILED_INIT',
+  EXECUTE_TRANSACTION_REVERT = 'EXECUTE_TRANSACTION_REVERT',
+}
+
+export enum ExecuteProcessorErrorMessage {
+  PROVIDER_INVALID_ENDPOINT = 'Invalid subnet endpoint',
+  CONTRACT_INVALID_ADDRESS = 'Invalid messaging contract address',
+  CONTRACT_INVALID_NO_CODE = 'Invalid messaging contract (no code at address)',
+  WALLET_INVALID_PRIVATE_KEY = 'Invalid private key',
+  CERTIFICATE_NOT_FOUND = 'A certificate with the provided receipt trie root could not be found',
+  EXECUTE_TRANSACTION_FAILED_INIT = 'The execute transaction could not be created',
+}
+
+export class ExecuteError extends Error {
+  constructor(type: ExecuteProcessorError, message?: string) {
+    const _message = JSON.stringify({
+      type,
+      message: message || ExecuteProcessorErrorMessage[type],
+    })
+    super(_message)
+    this.name = 'ExecuteError'
+  }
+}
+
+export interface ExecuteTransactionError {
+  decoded?: boolean
+  data: string
 }


### PR DESCRIPTION
# Description

This PR improves error handling in the `execute` processor. New errors are typed following an enum listing all errors potentially being thrown during the `execute` processor execution, and transaction revert error data is decoded if revert happened in `ToposMessaging` code (otherwise throws the raw data, to be decoded by the client). 

Fixes TOO-423

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
